### PR TITLE
feat: Added gfx902 to support GTT memory allocation; RX Vega 11, Ryzen 5 2400GE PRO

### DIFF
--- a/discover/amd_linux.go
+++ b/discover/amd_linux.go
@@ -59,6 +59,7 @@ var (
 		"gfx1036", // Generic RDNA2
 		"gfx940",  // MI300A (CDNA3)
 		"gfx90c",  // Radeon Vega 7 (Ryzen 5600G)
+		"gfx902",  // Radeon RX Vega 11 (Ryzen 5 2400G(E) (PRO))
 	}
 
 	// ApuUseGTT indicates whether GTT memory allocation is enabled for the current APU


### PR DESCRIPTION
Added gfx902 to support GTT memory allocation; RX Vega 11, Ryzen 5 2400GE PRO